### PR TITLE
Changed json dumps' indent None to 2

### DIFF
--- a/astrid/http.py
+++ b/astrid/http.py
@@ -24,7 +24,7 @@ def response(body, content_type='text/html; charset=utf-8'):
         kwargs['body'] = body.encode('utf-8')
     elif isinstance(body, dict):
         kwargs['content_type'] = 'application/json; charset=utf-8'
-        kwargs['body'] = json.dumps(body).encode('utf-8')
+        kwargs['body'] = json.dumps(body, indent=2).encode('utf-8')
     elif isinstance(body, int) or isinstance(body, float):
         kwargs['body'] = str(body).encode('utf-8')
 


### PR DESCRIPTION
Hi, I changed json dumps' indent None to 2.
It looks well and make development easier when to use in future.
